### PR TITLE
rewrite filters implementation because builtin filters weren't working

### DIFF
--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -29,15 +29,15 @@ def test_generate_template_content(mock_urlopen):
 
 def test_utc_to_pacific():
     """ test conversion of utc datetime string to pacific """
-    date_string = utc_to_pacific(mocks.UTC_DATETIME_STRING)
+    date_string = utc_to_pacific(None, mocks.UTC_DATETIME_STRING)
     assert date_string == mocks.PACIFIC_DATETIME_STRING
 
 def test_multiselect_dict_to_list():
     """ test conversion of multiselect to list """
-    team = multiselect_dict_to_list(mocks.TEAM_MEMBERS)
+    team = multiselect_dict_to_list(None, mocks.TEAM_MEMBERS)
     assert team == ["agent"]
 
 def test_uploads_to_list():
     """ test conversion of formio uploads to list """
-    uploads_list = uploads_to_list(mocks.UPLOADS)
+    uploads_list = uploads_to_list(None, mocks.UPLOADS)
     assert uploads_list == ["https://foo.s3.amazonaws.com/fake_file-3a3144b5-1050-4ceb-8bdc.pdf", "https://foo.s3.amazonaws.com/fake_file-3a3144b5-1050-4ceb-8bdc2.pdf"]

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -27,6 +27,19 @@ def test_generate_template_content(mock_urlopen):
     assert results[1]['type'] == 'text/plain'
     assert results[1]['value'] == 'Knights that say ni!'
 
+    # make sure builtin replace filter is working
+    mock_urlopen.return_value.__enter__.return_value.read.return_value = str.encode("{{ str_val | replace('hi', 'hello') }} world!")
+    results = generate_template_content({
+        'url': 'https://some.place.net',
+        'replacements': {
+            'str_val': 'hi'
+        }
+    })
+    assert results[0]['type'] == 'text/html'
+    assert results[0]['value'] == 'hello world!'
+    assert results[1]['type'] == 'text/plain'
+    assert results[1]['value'] == 'hello world!'
+
 def test_utc_to_pacific():
     """ test conversion of utc datetime string to pacific """
     date_string = utc_to_pacific(None, mocks.UTC_DATETIME_STRING)


### PR DESCRIPTION
I suspect the way that the code was setting the environment.filters variable to a new dictionary wiped out the dictionary which had the builtin filter mappings.  This new way adds the custom filters to the FILTERS object instead of creating a new dictionary.