### PR TITLE
fix: enable autoescape on email templates

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -126,7 +126,7 @@ def generate_template_content(template_params):
     index = template_params['url'].rfind('/')
     path = template_params['url'][:index+1]
     filename = template_params['url'][index+1:]
-    template_env = Environment(loader=UrlLoader(path))
+    template_env = Environment(loader=UrlLoader(path), autoescape=True)
     template = template_env.get_template(filename)
     html_content = template.render(template_params['replacements'])
 


### PR DESCRIPTION
As discussed in Slack, I'm proposing that we enable [autoescaping](https://jinja.palletsprojects.com/en/3.0.x/api/#autoescaping) (sanitization) in Jinja to combat [content injection](https://www.tenable.com/plugins/was/113212) attacks and, possibly, XSS attacks from malicious injected HTML.

This will escape markup in _every_ template interpolation, which may seem aggressive but is a more future-proof fix than adding field-level validation of every form that has an email integration which uses [one of the templates with field interpolations](https://github.com/search?q=repo%3ASFDigitalServices%2Fstatic-site+%22%7B%7B+data.%22&type=code&p=1).